### PR TITLE
Add a class to quiet quantum rootwrap logs

### DIFF
--- a/manifests/quantum_log.pp
+++ b/manifests/quantum_log.pp
@@ -1,0 +1,34 @@
+#
+# Add overriding rsyslog config file suppressing overzealous sudo logs
+# from the Ubuntu default quantum rootwrap configuration
+
+class coe::quantum_log {
+
+    package { 'rsyslog':
+        ensure  => 'installed',
+    }
+
+    file { '/etc/rsyslog.d/00-quantum_sudo.conf':
+        ensure  => 'file',
+        mode    => '0644',
+        owner   => 'root',
+        group   => 'root',
+        require => Package['rsyslog'],
+        content => template('coe/quantum_sudo_ubuntu.erb'),
+        notify  => Service['rsyslog'],
+    }
+
+    service { 'rsyslog':
+        ensure  => 'running',
+        enable  => true,
+        require => Package['rsyslog'],
+    }
+
+    file_line { 'quantum_sudoers_loglevels':
+        ensure    => 'present',
+        line      => 'Defaults:quantum syslog_badpri=err, syslog_goodpri=info',
+        path      => '/etc/sudoers.d/quantum_sudoers',
+        subscribe => Package['quantum'],
+    }
+
+}

--- a/templates/quantum_sudo_ubuntu.erb
+++ b/templates/quantum_sudo_ubuntu.erb
@@ -1,0 +1,2 @@
+authpriv.notice         /var/log/auth.log
+authpriv.*              ~


### PR DESCRIPTION
Add a class to disable default logging of successful quantum rootwrap
runs every second. Users can still enable logs if they need to see
these for policy reasons.
