### PR TITLE
Fix secrets for cinder-on-ceph

### DIFF
--- a/templates/secret.xml-compute.erb
+++ b/templates/secret.xml-compute.erb
@@ -1,5 +1,5 @@
 <secret ephemeral='no' private='no'>
   <usage type='ceph'>
-    <name><% $volume_keyname %> secret</name>
+    <name>client.admin secret</name>
   </usage>
 </secret>

--- a/templates/uuid_injection.erb
+++ b/templates/uuid_injection.erb
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-#export key=`ceph auth get-key client.admin`
-export key=`cat /etc/ceph/virsh.secret`
-sed -i "s,REPLACEME,${key},g" /etc/cinder/cinder.conf
+export uuid=`cat /etc/ceph/virsh.secret`
+sed -i "s,REPLACEME,${uuid},g" /etc/cinder/cinder.conf
 rm /etc/ceph/uuid_injection.sh

--- a/templates/uuid_injection.erb
+++ b/templates/uuid_injection.erb
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
-export key=`ceph auth get-key client.admin`
+#export key=`ceph auth get-key client.admin`
+export key=`cat /etc/ceph/virsh.secret`
 sed -i "s,REPLACEME,${key},g" /etc/cinder/cinder.conf
 rm /etc/ceph/uuid_injection.sh


### PR DESCRIPTION
The /etc/ceph/secret.xml file is currently malformed due to a
missing variable.  We're also not using the UUID generated
from the secret in cinder.conf like we should.  This
fixes both issues.
