### PR TITLE
Use cisco_supplemental repo for ceph pkgs

### DIFF
--- a/manifests/ceph/cinder.pp
+++ b/manifests/ceph/cinder.pp
@@ -7,11 +7,8 @@ class coe::ceph::cinder(
 
   Package['ceph'] -> Ceph::Key <<| title == 'admin' |>>
 
-  class { 'ceph::apt::ceph': release => $::ceph_release }
-
   package { 'python-ceph':
     ensure  => present,
-    require => Apt::Source['ceph'],
   }
  
   package { 'sysfsutils':

--- a/manifests/ceph/compute.pp
+++ b/manifests/ceph/compute.pp
@@ -7,16 +7,12 @@ class coe::ceph::compute(
 
   Package['ceph'] -> Ceph::Key <<| title == 'admin' |>>
 
-  class { 'ceph::apt::ceph': release => $::ceph_release }
-
   package { 'ceph-common':
     ensure  => present,
-    require => Apt::Source['ceph'],
   }
 
   package { 'python-ceph':
     ensure  => present,
-    require => Apt::Source['ceph'],
   }
  
   package { 'sysfsutils':

--- a/manifests/ceph/control.pp
+++ b/manifests/ceph/control.pp
@@ -6,11 +6,8 @@ class coe::ceph::control(
 
   Package['ceph'] -> Ceph::Key <<| title == 'admin' |>>
 
-  class { 'ceph::apt::ceph': release => $::ceph_release }
-
   package { 'ceph-common':
     ensure  => present,
-    require => Apt::Source['ceph'],
   }
 
   class { 'ceph::conf':


### PR DESCRIPTION
Use the cisco_supplemental repo for ceph packages, avoiding the need to add a ceph repo
