### PR TITLE
Bug 1216032 - missing dependency on parent dir

### DIFF
--- a/manifests/site_index.pp
+++ b/manifests/site_index.pp
@@ -20,4 +20,12 @@ class coe::site_index {
         group  => root,
         source => "puppet:///modules/coe/header-logo.png",
     }
+
+    file { "/var/www":
+        ensure => directory,
+        mode   => 0755,
+        owner  => root,
+        group  => root,
+    }
+
 }


### PR DESCRIPTION
Add parent dir to ensure it is present before files are created
