### PR TITLE
Move plugin

### DIFF
--- a/manifests/nexus.pp
+++ b/manifests/nexus.pp
@@ -12,7 +12,7 @@ $nexus_config      = undef
   file {'/etc/quantum/plugins/cisco/nexus.ini':
     owner => 'root',
     group => 'root',
-    content => template('nexus.ini.erb')
+    content => template('coe/nexus.ini.erb')
   } ~> Service['quantum-server']
 
   if !$nexus_credentials {

--- a/manifests/nexus.pp
+++ b/manifests/nexus.pp
@@ -1,0 +1,49 @@
+class coe::nexus (
+$nexus_credentials = undef,
+$nexus_config      = undef
+) 
+{
+  package { 'python-ncclient':
+    ensure => installed,
+  } ~> Service['quantum-server']
+
+  # hack to make sure the directory is created
+  Quantum_plugin_cisco<||> ->
+  file {'/etc/quantum/plugins/cisco/nexus.ini':
+    owner => 'root',
+    group => 'root',
+    content => template('nexus.ini.erb')
+  } ~> Service['quantum-server']
+
+  if !$nexus_credentials {
+    fail('No nexus credentials specified')
+  }
+
+  if !$nexus_config {
+    fail('No nexus config specified')
+  }
+
+  file {'/var/lib/quantum/.ssh':
+    ensure => directory,
+    owner  => 'quantum',
+    require => Package['quantum-server']
+  }
+  nexus_creds{ $nexus_credentials:
+    require => File['/var/lib/quantum/.ssh']
+  }
+}
+
+define nexus_creds {
+  $args = split($title, '/')
+  quantum_plugin_cisco_credentials {
+    "${args[0]}/username": value => $args[1];
+    "${args[0]}/password": value => $args[2];
+  }
+  exec {"${title}":
+    unless => "/bin/cat /var/lib/quantum/.ssh/known_hosts | /bin/grep ${args[0]}",
+    command => "/usr/bin/ssh-keyscan -t rsa ${args[0]} >> /var/lib/quantum/.ssh/known_hosts",
+    user    => 'quantum',
+    require => Package['quantum-server']
+  }
+}
+

--- a/templates/nexus.ini.erb
+++ b/templates/nexus.ini.erb
@@ -1,0 +1,14 @@
+[DRIVER]
+name=quantum.plugins.cisco.nexus.cisco_nexus_network_driver_v2.CiscoNEXUSDriver
+
+[SWITCH]
+<% @nexus_config.each do |switch_ip, hosts| %>
+[[<%= switch_ip %>]]
+<% hosts.each do |host_name, ports| %>
+[[[<%=host_name%>]]]
+ports=<%=ports%>
+<% end %>
+[[[ssh_port]]]
+ssh_port=22
+<% end %>
+


### PR DESCRIPTION
Since the nexus puppetry needs more work
before it can be upstreamed, and the config
format will be changing in havana, this patch
moves the nexus puppetry into this module
and out of grizzly-manifests until it can
be re-done for havana in puppet-quantum.
