### PR TITLE
Fix unqualified paths in coe::ceph classes

### DIFF
--- a/manifests/ceph/cinder.pp
+++ b/manifests/ceph/cinder.pp
@@ -36,20 +36,19 @@ class coe::ceph::cinder(
   }
  
   exec { 'copy the admin key to make cinder work':
-    command => 'cp /etc/ceph/keyring /etc/ceph/client.admin',
+    command => '/bin/cp /etc/ceph/keyring /etc/ceph/client.admin',
     creates => '/etc/ceph/client.admin',
     require => [ Package['ceph'], Ceph::Key['admin'] ],
   }
 
   exec { 'get-or-set virsh secret':
-    command => '/usr/bin/virsh secret-define --file /etc/ceph/secret.xml | /usr/bin/awk \'{print $2}\' | sed \'/^$/d\' > /etc/ceph/virsh.secret',
+    command => '/usr/bin/virsh secret-define --file /etc/ceph/secret.xml | /usr/bin/awk \'{print $2}\' | /bin/sed \'/^$/d\' > /etc/ceph/virsh.secret',
     creates => "/etc/ceph/virsh.secret",
     require => [ Package['ceph'], Ceph::Key['admin'], File['/etc/ceph/secret.xml'] ],
   }
 
   exec { 'set-secret-value virsh':
-    command => "/usr/bin/virsh secret-set-value --secret $(cat /etc/ceph/virsh.secret) --base64 $(ceph auth get-key client.admin)",
+    command => "/usr/bin/virsh secret-set-value --secret $(cat /etc/ceph/virsh.secret) --base64 $(/usr/bin/ceph auth get-key client.admin)",
     require => Exec['get-or-set virsh secret'],
   }
-
 }

--- a/manifests/ceph/combined.pp
+++ b/manifests/ceph/combined.pp
@@ -14,9 +14,9 @@ class coe::ceph::combined(
   }
 
   exec { 'copy the admin key to make cinder work':
-    command => 'cp /etc/ceph/keyring /etc/ceph/client.admin',
+    command => '/bin/cp /etc/ceph/keyring /etc/ceph/client.admin',
     creates => '/etc/ceph/client.admin',
-    unless  => 'test -e /etc/ceph/client.admin',
+    unless  => '/usr/bin/test -e /etc/ceph/client.admin',
   }
 
   file { '/etc/ceph/client.admin':
@@ -31,14 +31,14 @@ class coe::ceph::combined(
   }
 
   exec { 'get-or-set virsh secret':
-    command => '/usr/bin/virsh secret-define --file /etc/ceph/secret.xml | /usr/bin/awk \'{print $2}\' | sed \'/^$/d\' > /etc/ceph/virsh.secret',
+    command => '/usr/bin/virsh secret-define --file /etc/ceph/secret.xml | /usr/bin/awk \'{print $2}\' | /bin/sed \'/^$/d\' > /etc/ceph/virsh.secret',
     creates => "/etc/ceph/virsh.secret",
-    unless  => "test -e /etc/ceph/virsh.secret",
+    unless  => "/usr/bin/test -e /etc/ceph/virsh.secret",
     require => File['/etc/ceph/secret.xml'],
   }
 
   exec { 'set-secret-value virsh':
-    command => "/usr/bin/virsh secret-set-value --secret $(cat /etc/ceph/virsh.secret) --base64 $(ceph auth get-key client.admin)",
+    command => "/usr/bin/virsh secret-set-value --secret $(/bin/cat /etc/ceph/virsh.secret) --base64 $(/usr/bin/ceph auth get-key client.admin)",
     require => Exec['get-or-set virsh secret'],
   }
 
@@ -59,6 +59,4 @@ class coe::ceph::combined(
       require => Exec['set-secret-value virsh'],
     }
   }
-
-
 }

--- a/manifests/ceph/compute.pp
+++ b/manifests/ceph/compute.pp
@@ -40,19 +40,19 @@ class coe::ceph::compute(
   }
  
   exec { 'copy the admin key to make cinder work':
-    command => 'cp /etc/ceph/keyring /etc/ceph/client.admin',
+    command => '/bin/cp /etc/ceph/keyring /etc/ceph/client.admin',
     creates => '/etc/ceph/client.admin',
     require => [ Package['ceph'], Ceph::Key['admin'] ],
   }
 
   exec { 'get-or-set virsh secret':
-    command => '/usr/bin/virsh secret-define --file /etc/ceph/secret.xml | /usr/bin/awk \'{print $2}\' | sed \'/^$/d\' > /etc/ceph/virsh.secret',
+    command => '/usr/bin/virsh secret-define --file /etc/ceph/secret.xml | /usr/bin/awk \'{print $2}\' | /bin/sed \'/^$/d\' > /etc/ceph/virsh.secret',
     creates => "/etc/ceph/virsh.secret",
     require => [ Package['ceph'], Ceph::Key['admin'], File['/etc/ceph/secret.xml'] ],
   }
 
   exec { 'set-secret-value virsh':
-    command => "/usr/bin/virsh secret-set-value --secret $(cat /etc/ceph/virsh.secret) --base64 $(ceph auth get-key client.admin)",
+    command => "/usr/bin/virsh secret-set-value --secret $(/bin/cat /etc/ceph/virsh.secret) --base64 $(/usr/bin/ceph auth get-key client.admin)",
     require => Exec['get-or-set virsh secret'],
   }
 
@@ -61,5 +61,4 @@ class coe::ceph::compute(
     unless  => "/usr/bin/rados lspools | grep -sq volumes",
     require => Exec['set-secret-value virsh'],
   }
-
 }

--- a/manifests/ceph/control.pp
+++ b/manifests/ceph/control.pp
@@ -32,7 +32,7 @@ class coe::ceph::control(
   }
 
   exec { 'copy the admin key':
-    command => 'cp /etc/ceph/keyring /etc/ceph/client.admin',
+    command => '/bin/cp /etc/ceph/keyring /etc/ceph/client.admin',
     creates => '/etc/ceph/client.admin',
     require => Package['ceph'],
   }
@@ -45,5 +45,4 @@ class coe::ceph::control(
       notify  => [ Service['glance-api'], Service['glance-registry'] ],
     }
   }
-
 }


### PR DESCRIPTION
Fix unqualified paths in coe::ceph classes

Several commands in the coe::ceph classes don't have fully qualified paths, which can cause Puppet to throw errors.  This patch adds full paths to several commands.

Closes-Bug: #1231098
