### PR TITLE
Adds support for patching OpenStack services

### DIFF
--- a/files/impl_kombu.py.patch
+++ b/files/impl_kombu.py.patch
@@ -1,0 +1,21 @@
+diff --git a/nova/openstack/common/rpc/impl_kombu.py b/nova/openstack/common/rpc/impl_kombu.py
+index 81afc2a..45f6f03 100644
+--- a/openstack/common/rpc/impl_kombu.py
++++ b/openstack/common/rpc/impl_kombu.py
+@@ -488,6 +488,7 @@ class Connection(object):
+             self.connection = None
+         self.connection = kombu.connection.BrokerConnection(**params)
+         self.connection_errors = self.connection.connection_errors
++        self.channel_errors = self.connection.channel_errors
+         if self.memory_transport:
+             # Kludge to speed up tests.
+             self.connection.transport.polling_interval = 0.0
+@@ -561,7 +562,7 @@ class Connection(object):
+         while True:
+             try:
+                 return method(*args, **kwargs)
+-            except (self.connection_errors, socket.timeout, IOError), e:
++            except (self.connection_errors, self.channel_errors, socket.timeout, IOError), e:
+                 if error_callback:
+                     error_callback(e)
+             except Exception, e:

--- a/manifests/patch.pp
+++ b/manifests/patch.pp
@@ -1,0 +1,8 @@
+# Class to ensure the necessary packages are present
+# to patch OpenStack services.
+#
+class coe::patch {
+  package { 'patch':
+    ensure => present,
+  }
+}

--- a/manifests/patch/nova-rabbitmq.pp
+++ b/manifests/patch/nova-rabbitmq.pp
@@ -1,0 +1,23 @@
+# This class installs a patch to nova that enables RabbitMQ HA support.
+# Addresses bug: https://bugs.launchpad.net/oslo/+bug/856764
+#
+class coe::patch::nova-rabbitmq (
+) {
+
+  include coe::patch
+  
+  file { "/tmp/impl_kombu.py.patch":
+    ensure => present,
+    source => 'puppet:///modules/coe/impl_kombu.py.patch'
+  }
+  
+  exec { "patch-nova":
+    unless    => '/bin/grep self.channel_errors /usr/lib/python2.7/dist-packages/nova/openstack/common/rpc/impl_kombu.py',
+    command   => '/usr/bin/patch -p1 -d /usr/lib/python2.7/dist-packages/nova </tmp/impl_kombu.py.patch',
+    require   => [[File['/tmp/impl_kombu.py.patch']],[Package['patch', 'python-nova']]],
+  } ->
+  # Do this BEFORE any nova scheduler is started, otherwise
+  # queues will be declared in non-HA mode which cannot be fixed
+  # without erasing the Rabbit database.
+  Package<| name == 'nova-scheduler' |>
+}


### PR DESCRIPTION
This commit adds support for patching OpenStack services.  This
will help retire the openstack-ha module which will no longer be
needed with the completion of the openstack-installer project.
This will also allow us to manage patches that COI/COE will
support.

The first patch being implemented is for impl_kombu.py, which
is needed to address the following HA-related bug:

https://bugs.launchpad.net/oslo/+bug/856764
