### PR TITLE
Fixes network::interface bugs

### DIFF
--- a/manifests/network/interface.pp
+++ b/manifests/network/interface.pp
@@ -38,12 +38,10 @@ class coe::network::interface(
   $onboot         = 'true'
 ) {
 
-  include network
-
   network_config { $interface_name:
     ensure     => $ensure,
     hotplug    => $hotplug,
-    family     => $fmaily,
+    family     => $family,
     method     => $method,
     ipaddress  => $ipaddress,
     netmask    => $netmask,


### PR DESCRIPTION
1. Removes the unneeded include network statement.
2. Fixes family spelling error.
