### PR TITLE
Adds Support for Network Interface Options

### DIFF
--- a/manifests/network/interface.pp
+++ b/manifests/network/interface.pp
@@ -35,7 +35,8 @@ class coe::network::interface(
   $hotplug        = 'false',
   $family         = 'inet',
   $method         = 'static',
-  $onboot         = 'true'
+  $onboot         = 'true',
+  $options        = undef
 ) {
 
   network_config { $interface_name:
@@ -46,7 +47,8 @@ class coe::network::interface(
     ipaddress  => $ipaddress,
     netmask    => $netmask,
     onboot     => $onboot,
-    notify     => Exec['network-restart']
+    notify     => Exec['network-restart'],
+    options    => $options
   }
 
   # Changed from service to exec due to Ubuntu bug #440179


### PR DESCRIPTION
Previously, the class did not support managing network interface
options.  This is required for nodes that have network interfaces
configured for bridged mode (i.e. control/compute nodes).

The patch adds the $options parameter which defaults to undef for
backwards compatibility and for network interface options not to
be configured.
