### PR TITLE
Remove unused pip support

### DIFF
--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -161,25 +161,6 @@ UcXHbA==
 
   }
 
-  include pip
-
-  # Ensure that the pip packages are fetched appropriately when we're using an
-  # install where there's no direct connection to the net from the openstack
-  # nodes
-  if ! $node_gateway {
-    Package <| provider=='pip' |> {
-      install_options => "--index-url=http://${build_node_name}/packages/simple/",
-    }
-  } else {
-    if($::proxy) {
-      Package <| provider=='pip' |> {
-        install_options => "--proxy=$proxy"
-      }
-    }
-  }
-  # (the equivalent work for apt is done by the cobbler boot, which 
-  # sets this up as a part of the installation.)
-
   # /etc/hosts entries for the controller nodes
   host { $controller_hostname:
     ip => $controller_node_internal


### PR DESCRIPTION
Remove pip from the coe::base class now that all required packages are
installed via deb packages instead of via pip archives.
