### PR TITLE
Migrate coe::nexus from quantum->neutron

### DIFF
--- a/manifests/nexus.pp
+++ b/manifests/nexus.pp
@@ -5,15 +5,15 @@ $nexus_config      = undef
 {
   package { 'python-ncclient':
     ensure => installed,
-  } ~> Service['quantum-server']
+  } ~> Service['neutron-server']
 
   # hack to make sure the directory is created
-  Quantum_plugin_cisco<||> ->
-  file {'/etc/quantum/plugins/cisco/nexus.ini':
+  Neutron_plugin_cisco<||> ->
+  file {'/etc/neutron/plugins/cisco/nexus.ini':
     owner => 'root',
     group => 'root',
     content => template('coe/nexus.ini.erb')
-  } ~> Service['quantum-server']
+  } ~> Service['neutron-server']
 
   if !$nexus_credentials {
     fail('No nexus credentials specified')
@@ -23,28 +23,28 @@ $nexus_config      = undef
     fail('No nexus config specified')
   }
 
-  file {'/var/lib/quantum/.ssh':
+  file {'/var/lib/neutron/.ssh':
     ensure => directory,
-    owner  => 'quantum',
-    require => Package['quantum-server']
+    owner  => 'neutron',
+    require => Package['neutron-server']
   }
   nexus_creds{ $nexus_credentials:
-    require => [ File['/var/lib/quantum/.ssh'],
-                 File['/etc/quantum/plugins/cisco/nexus.ini'] ]
+    require => [ File['/var/lib/neutron/.ssh'],
+                 File['/etc/neutron/plugins/cisco/nexus.ini'] ]
   }
 }
 
 define nexus_creds {
   $args = split($title, '/')
-  quantum_plugin_cisco_credentials {
+  neutron_plugin_cisco_credentials {
     "${args[0]}/username": value => $args[1];
     "${args[0]}/password": value => $args[2];
   }
   exec {"${title}":
-    unless => "/bin/cat /var/lib/quantum/.ssh/known_hosts | /bin/grep ${args[0]}",
-    command => "/usr/bin/ssh-keyscan -t rsa ${args[0]} >> /var/lib/quantum/.ssh/known_hosts",
-    user    => 'quantum',
-    require => Package['quantum-server']
+    unless => "/bin/cat /var/lib/neutron/.ssh/known_hosts | /bin/grep ${args[0]}",
+    command => "/usr/bin/ssh-keyscan -t rsa ${args[0]} >> /var/lib/neutron/.ssh/known_hosts",
+    user    => 'neutron',
+    require => Package['neutron-server']
   }
 }
 

--- a/templates/nexus.ini.erb
+++ b/templates/nexus.ini.erb
@@ -1,5 +1,5 @@
 [DRIVER]
-name=quantum.plugins.cisco.nexus.cisco_nexus_network_driver_v2.CiscoNEXUSDriver
+name=neutron.plugins.cisco.nexus.cisco_nexus_network_driver_v2.CiscoNEXUSDriver
 
 [SWITCH]
 <% @nexus_config.each do |switch_ip, hosts| %>


### PR DESCRIPTION
The coe::nexus class was still referring to OpenStack
Networking as Quantum.  Since the name was changed to
Neutron in Havana, we need to follow suit.  This patch
changes all references from Quantum to Neutron.

Partial-Bug: #1276168
