### PR TITLE
Fix /etc/hosts entry generated by coe::base

### DIFF
--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -9,6 +9,7 @@ class coe::base(
   $build_node_name,
   $controller_hostname,
   $controller_node_internal,
+  $domain_name,
   $package_repo            = 'cisco_repo',
   $openstack_release       = 'havana',
   $openstack_repo_location = false,
@@ -162,8 +163,9 @@ UcXHbA==
   }
 
   # /etc/hosts entries for the controller nodes
-  host { $controller_hostname:
-    ip => $controller_node_internal
+  host { "$controller_hostname.$domain_name":
+    ip           => $controller_node_internal,
+    host_aliases => $controller_hostname,
   }
 
   include collectd


### PR DESCRIPTION
Populate /etc/hosts with the standard IP, FQDN, bare hostname tuple.

Partial-Bug: #1277712

Requires https://review.openstack.org/72997 to merge first
