### PR TITLE
Remove references to ftpeng.cisco.com

### DIFF
--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -75,10 +75,6 @@ UcXHbA==
       $openstack_repo_location_real = "${openstack_repo_location}/cisco"
       warning("openstack_repo_location has changed format and was set to a known bad value (see bug #1269856), setting to $openstck_repo_location_real")
     }
-    elsif ($openstack_repo_location == 'ftp://ftpeng.cisco.com/openstack'){
-      $openstack_repo_location_real = "${openstack_repo_location}/cisco"
-      warning("openstack_repo_location has changed format and was set to a known bad value (see bug #1269856), setting to $openstck_repo_location_real")
-    }
     else {
       $openstack_repo_location_real = $openstack_repo_location
     }


### PR DESCRIPTION
The ftpeng hosting site is being replaced by Cisco IT, and new files
cannot currently be uploaded to it. While previous releases of COI can
continue to use ftpeng.cisco.com as a package mirror, new releases of
COI should not contain any references to it so the site won't contain
any updates from after Feb 14th. Alternate FTP-based hosting is being
looked into, but isn't likely to be ready before the h.2 release. Just
to note: starting in at least h.0 the default package hosting site in
COI is http://openstack-repo.cisco.com and demand for FTP hosting is
very small anyway, so it's unlikely that this will affect anyone.

Partial-Bug: #1281784
