### PR TITLE
Removed spurious collectd reference.

### DIFF
--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -163,6 +163,4 @@ UcXHbA==
     ip           => $controller_node_internal,
     host_aliases => $controller_hostname,
   }
-
-  include collectd
 }

--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -18,7 +18,6 @@ class coe::base(
   $ubuntu_repo             = 'updates',
   # optional external services
   $node_gateway            = false,
-  $proxy                   = false,
 ) {
 
   # Disable pipelining to avoid unfortunate interactions between apt and
@@ -86,7 +85,6 @@ UcXHbA==
         release     => "${openstack_release}${pocket}",
         repos       => "main",
         key         => "E8CC67053ED3B199",
-        proxy       => $proxy,
         key_content => $cisco_key_content,
       }
 
@@ -101,7 +99,6 @@ UcXHbA==
           release     => "${openstack_release}${pocket}",
           repos       => "main",
           key         => "E8CC67053ED3B199",
-          proxy       => $proxy,
           key_content => $cisco_key_content,
         }
         apt::pin { "cisco_supplemental":

--- a/manifests/network/interface.pp
+++ b/manifests/network/interface.pp
@@ -36,25 +36,28 @@ class coe::network::interface(
   $family         = 'inet',
   $method         = 'static',
   $onboot         = 'true',
-  $options        = undef
+  $options        = undef,
+  $enabled        = true,
 ) {
 
-  network_config { $interface_name:
-    ensure     => $ensure,
-    hotplug    => $hotplug,
-    family     => $family,
-    method     => $method,
-    ipaddress  => $ipaddress,
-    netmask    => $netmask,
-    onboot     => $onboot,
-    notify     => Exec['network-restart'],
-    options    => $options
-  }
+  if ($enable) {
+    network_config { $interface_name:
+      ensure     => $ensure,
+      hotplug    => $hotplug,
+      family     => $family,
+      method     => $method,
+      ipaddress  => $ipaddress,
+      netmask    => $netmask,
+      onboot     => $onboot,
+      notify     => Exec['network-restart'],
+      options    => $options
+    }
 
-  # Changed from service to exec due to Ubuntu bug #440179
-  exec { 'network-restart':
-    command     => '/etc/init.d/networking restart',
-    path        => '/usr/bin:/usr/sbin:/bin:/sbin',
-    refreshonly => true
+    # Changed from service to exec due to Ubuntu bug #440179
+    exec { 'network-restart':
+      command     => '/etc/init.d/networking restart',
+      path        => '/usr/bin:/usr/sbin:/bin:/sbin',
+      refreshonly => true
+    }
   }
 }


### PR DESCRIPTION
All of the collectd/nagios/graphite support is actually in the `coi` module, and this appears to be completely unnecessary.  This prevents users from not installing collectd even if they've set the `enable_monitoring` hiera key to false.
