### PR TITLE
Fix duplicate host resource

### DIFF
--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -159,10 +159,11 @@ UcXHbA==
   }
 
   # /etc/hosts entries for the controller nodes
-  host { "$controller_hostname.$domain_name":
+  ensure_resource ( 'host', "$controller_hostname.$domain_name", {
     ip           => $controller_node_internal,
     host_aliases => $controller_hostname,
-  }
+    }
+  )
 
   include collectd
 }


### PR DESCRIPTION
In some circumstances, the puppet-coe class may cause a duplicate
resource error due to host definition clashing with
puppet_openstack_builder's setup.pp manifest.  This patch prevents
the problem by creating the host entry with create_resource
instead of creating it explicitly.

Closes-Bug: #1292772
(cherry picked from commit 4ead041c3eba175ff21ec95595312024e3691a85)
