### PR TITLE
Removed spurious collectd reference

### DIFF
--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -254,6 +254,4 @@ ykz5a/8840rWqc7sLA7lKA==
     host_aliases => $controller_hostname,
     }
   )
-
-  include collectd
 }


### PR DESCRIPTION
There's a old reference to the collectd module hanging around in
puppet-coe that isn't necessary any longer thanks to other changes.
It's presence there causes collectd to get installed even if
users remove it from the class group mapping.  This patch removes
the reference.

Thanks to dvorak (Clayton O'Neill) for finding and suggesting
the fix.

Closes-Bug: #1304179
