### PR TITLE
Removed spurious collectd reference

### DIFF
--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -164,6 +164,4 @@ UcXHbA==
     host_aliases => $controller_hostname,
     }
   )
-
-  include collectd
 }


### PR DESCRIPTION
There's a old reference to the collectd module hanging around in
puppet-coe that isn't necessary any longer thanks to other changes.
It's presence there causes collectd to get installed even if
users remove it from the class group mapping.  This patch removes
the reference.

Thanks to dvorak (Clayton O'Neill) for finding and suggesting
the fix.

Closes-Bug: #1304179
(cherry picked from commit cfcfd0551becf1b3c3bcbd177e2fe96b1fe59045)
